### PR TITLE
Fixed DAO instatiation

### DIFF
--- a/src/main/java/org/pahappa/dao/AdmissionDao.java
+++ b/src/main/java/org/pahappa/dao/AdmissionDao.java
@@ -3,8 +3,11 @@ package org.pahappa.dao;
 import org.hibernate.Session;
 import org.pahappa.model.Admission;
 import org.pahappa.service.HibernateUtil;
+
+import javax.enterprise.context.ApplicationScoped;
 import java.util.List;
 
+@ApplicationScoped
 public class AdmissionDao extends BaseDao<Admission, Long> {
 
     public AdmissionDao() {

--- a/src/main/java/org/pahappa/dao/AppointmentDao.java
+++ b/src/main/java/org/pahappa/dao/AppointmentDao.java
@@ -4,8 +4,10 @@ import org.hibernate.Session;
 import org.pahappa.model.Appointment;
 import org.pahappa.service.HibernateUtil;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.util.List;
 
+@ApplicationScoped
 public class AppointmentDao extends BaseDao<Appointment, Long> {
 
     public AppointmentDao() {

--- a/src/main/java/org/pahappa/dao/MedicalRecordDao.java
+++ b/src/main/java/org/pahappa/dao/MedicalRecordDao.java
@@ -3,8 +3,11 @@ package org.pahappa.dao;
 import org.hibernate.Session;
 import org.pahappa.model.MedicalRecord;
 import org.pahappa.service.HibernateUtil;
+
+import javax.enterprise.context.ApplicationScoped;
 import java.util.List;
 
+@ApplicationScoped
 public class MedicalRecordDao extends BaseDao<MedicalRecord, Long> {
 
     public MedicalRecordDao() {

--- a/src/main/java/org/pahappa/service/admission/impl/AdmissionServiceImpl.java
+++ b/src/main/java/org/pahappa/service/admission/impl/AdmissionServiceImpl.java
@@ -16,7 +16,8 @@ import java.util.List;
 @ApplicationScoped
 public class AdmissionServiceImpl implements AdmissionService {
 
-    private final AdmissionDao admissionDao = new AdmissionDao();
+    @Inject
+    private AdmissionDao admissionDao;
 
     @Inject
     private StaffService staffService;

--- a/src/main/java/org/pahappa/service/appointment/impl/AppointmentServiceImpl.java
+++ b/src/main/java/org/pahappa/service/appointment/impl/AppointmentServiceImpl.java
@@ -11,6 +11,7 @@ import org.pahappa.utils.Role;
 import org.pahappa.model.Patient;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.util.Date;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -19,7 +20,8 @@ import java.util.List;
 @ApplicationScoped
 public class AppointmentServiceImpl implements AppointmentService {
 
-    private final AppointmentDao appointmentDao = new AppointmentDao();
+    @Inject
+    private AppointmentDao appointmentDao;
 
     @Override
     public List<Appointment> getAllAppointments() {

--- a/src/main/java/org/pahappa/service/medicalRecord/impl/MedicalRecordServiceImpl.java
+++ b/src/main/java/org/pahappa/service/medicalRecord/impl/MedicalRecordServiceImpl.java
@@ -5,12 +5,14 @@ import org.pahappa.model.MedicalRecord;
 import org.pahappa.service.medicalRecord.MedicalRecordService;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.util.List;
 
 @ApplicationScoped
 public class MedicalRecordServiceImpl implements MedicalRecordService {
 
-    private final MedicalRecordDao medicalRecordDao = new MedicalRecordDao();
+    @Inject
+    private  MedicalRecordDao medicalRecordDao;
 
     @Override
     public void saveMedicalRecord(MedicalRecord record) {


### PR DESCRIPTION
Many service implementations directly instantiate DAOs using new (e.g., private final AdmissionDao admissionDao = new AdmissionDao();). This bypasses CDI (Contexts and Dependency Injection), making services harder to test, less flexible, and violates the dependency inversion principle.